### PR TITLE
Moving backlog toggle to header

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -120,20 +120,20 @@ class Toolbar extends Component {
 
                 <Popover
                     className="Toolbar-button Toolbar-button-popover"
-                    content={<DueDateFilterMenu />}
-                    interactionKind={PopoverInteractionKind.CLICK}
-                    popoverClassName="pt-popover-content-sizing"
-                    position={Position.BOTTOM}>
-                    <Button text="Due Date" iconName="calendar" className="Toolbar-button" />
-                </Popover>
-
-                <Popover
-                    className="Toolbar-button Toolbar-button-popover"
                     content={priorityFilterMenu}
                     interactionKind={PopoverInteractionKind.CLICK}
                     popoverClassName="pt-popover-content-sizing"
                     position={Position.BOTTOM}>
                     <Button text="Priority" iconName="flag" className="Toolbar-button" />
+                </Popover>
+
+                <Popover
+                    className="Toolbar-button Toolbar-button-popover"
+                    content={<DueDateFilterMenu />}
+                    interactionKind={PopoverInteractionKind.CLICK}
+                    popoverClassName="pt-popover-content-sizing"
+                    position={Position.BOTTOM}>
+                    <Button text="Due Date" iconName="calendar" className="Toolbar-button" />
                 </Popover>
 
                 <Button

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -100,13 +100,6 @@ class Toolbar extends Component {
 
         return (
             <div className="Toolbar">
-                <Button
-                    text="Backlog"
-                    iconName="comparison"
-                    className="Toolbar-button"
-                    onClick={this.props.toggleBacklog}
-                />
-                <span className="light-divider pt-navbar-divider" />
                 <Popover
                     className="Toolbar-button Toolbar-button-popover"
                     content={listsFilterMenu}

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -105,7 +105,7 @@ class Toolbar extends Component {
                     content={listsFilterMenu}
                     interactionKind={PopoverInteractionKind.CLICK}
                     popoverClassName="pt-popover-content-sizing"
-                    position={Position.BOTTOM}>
+                    position={Position.BOTTOM_LEFT}>
                     <Button text="Lists" iconName="property" className="Toolbar-button" />
                 </Popover>
 

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -112,7 +112,6 @@ const mapDispatchToProps = dispatch => {
         },
         toggleBacklog: () => {
             dispatch(uiActions.toggleBacklog());
-            return;
         },
     };
 };

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -25,6 +25,16 @@ class Header extends React.Component {
             />
         );
 
+        const backlogButton = (
+            <AnchorButton
+                text="Backlog"
+                iconName="comparison"
+                className="light-text header-right"
+                onClick={this.props.toggleBacklog}
+                intent={Intent.PRIMARY}
+            />
+        );
+
         const syncButton = (
             <AnchorButton
                 className="light-text header-right"
@@ -69,6 +79,7 @@ class Header extends React.Component {
                 </div>
                 <div className="pt-navbar-group pt-align-right hide-if-small-500">
                     {showBoardButtons ? (fetching ? spinner : syncButton) : emptyDiv}
+                    {showBoardButtons ? backlogButton : emptyDiv}
                     {showBoardButtons ? toggleToolbarButton : emptyDiv}
                     {loggedIn ? logoutButton : loginButton}
                 </div>
@@ -98,6 +109,10 @@ const mapDispatchToProps = dispatch => {
 
         toggleToolbar: () => {
             dispatch(uiActions.toggleToolbar());
+        },
+        toggleBacklog: () => {
+            dispatch(uiActions.toggleBacklog());
+            return;
         },
     };
 };


### PR DESCRIPTION
Hi @mwakerman ,

I've moved the backlog toggle to the header bar next to the other action buttons and removed it from the filter bar.

**New location:**
![image](https://user-images.githubusercontent.com/2660760/47837363-a42c2680-de10-11e8-9db9-8a7b4ca30ace.png)

**Filter bar:**
![image](https://user-images.githubusercontent.com/2660760/47837402-ca51c680-de10-11e8-90f3-2b405f344d7f.png)

Let me know what you think 
This closes #2 