### PR TITLE
Add dynamic due date filter for today

### DIFF
--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -178,6 +178,15 @@ class Board extends Component {
                             return false;
                         }
                         break;
+                    case NAMED_FILTERS.TODAY:
+                        if (!item.due_date_utc) {
+                            return false;
+                        }
+
+                        if (moment(item.due_date_utc).isAfter(moment())) {
+                            return false;
+                        }
+                        break;
                     case NAMED_FILTERS.NO_DUE_DATE:
                         if (item.due_date_utc) {
                             return false;

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -174,7 +174,7 @@ class Board extends Component {
                             return false;
                         }
 
-                        if (moment(item.due_date_utc).isAfter(moment().add(7, 'days'))) {
+                        if (moment(item.due_date_utc).isAfter(moment().add(7, 'days'), 'day')) {
                             return false;
                         }
                         break;
@@ -183,7 +183,7 @@ class Board extends Component {
                             return false;
                         }
 
-                        if (moment(item.due_date_utc).isAfter(moment())) {
+                        if (moment(item.due_date_utc).isAfter(moment(), 'day')) {
                             return false;
                         }
                         break;

--- a/src/components/DueDateFilterMenu.js
+++ b/src/components/DueDateFilterMenu.js
@@ -76,6 +76,19 @@ class DueDateFilterMenu extends React.Component {
                 />
                 <Button
                     className="Toolbar-button"
+                    text="Today"
+                    title="Dynamic filter"
+                    onClick={() => {
+                        if (namedFilter === NAMED_FILTERS.TODAY) {
+                            this.handleNamedFilter(null);
+                        } else {
+                            this.handleNamedFilter(NAMED_FILTERS.TODAY);
+                        }
+                    }}
+                    active={namedFilter === NAMED_FILTERS.TODAY}
+                />
+                <Button
+                    className="Toolbar-button"
                     text="No Due Date"
                     onClick={() => {
                         if (namedFilter === NAMED_FILTERS.NO_DUE_DATE) {

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -125,8 +125,8 @@ class List extends React.Component {
                     break;
                 case SORT_BY.PRIORITY:
                     target = item.priority;
-                    spacerIndex = listItemToRender.findIndex(
-                        i => (isAscending ? i.priority < target : i.priority > target)
+                    spacerIndex = listItemToRender.findIndex(i =>
+                        isAscending ? i.priority < target : i.priority > target
                     );
                     break;
                 case SORT_BY.PROJECT_ORDER:

--- a/src/redux/modules/lists.js
+++ b/src/redux/modules/lists.js
@@ -37,6 +37,7 @@ export const HIDDEN_REASON = {
 
 export const NAMED_FILTERS = {
     NEXT_7_DAYS: 'NEXT_7_DAYS',
+    TODAY: 'TODAY',
     NO_DUE_DATE: 'NO_DUE_DATE',
 };
 


### PR DESCRIPTION
Hi! This PR adds a today filter for the dynamic due date, but doesn't modify the calendar section.

I also modified the due date comparison to only compare the date, not the time, since that's Todoist behavior.

Do let me know if further changes are needed.

Tested:
- [x] Restoring filter from URL query parameters
- [x] Filters out items due tomorrow 00:01am (after adding `day` granularity to `isAfter()`)
- [x] Filters out items with no due date
- [x] Filters out items due tomorrow

Closes #21 

![image](https://user-images.githubusercontent.com/20269588/48368008-1fdf6c00-e678-11e8-9c77-e194fbb067ad.png)
