### PR TITLE
Add confirmation step before deleting list

### DIFF
--- a/src/components/List.js
+++ b/src/components/List.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { DropTarget } from 'react-dnd';
 import flow from 'lodash/flow';
-import { Intent } from '@blueprintjs/core';
+import { Alert, Intent } from '@blueprintjs/core';
 
 import ListTitle from './ListTitle';
 import ListItem from './ListItem';
@@ -21,6 +21,7 @@ class List extends React.Component {
         super(props);
         this.state = {
             allChecked: false,
+            isDeleteConfirmationOpen: false,
         };
     }
 
@@ -75,8 +76,40 @@ class List extends React.Component {
         );
     };
 
-    handleDelete = () => {
+    renderDeleteConfirmation = () => {
+        const { list } = this.props;
+        const { isDeleteConfirmationOpen } = this.state;
+
+        return (
+            <Alert
+                canEscapeKeyCancel={true}
+                canOutsideClickCancel={true}
+                cancelButtonText="Cancel"
+                confirmButtonText="Delete list"
+                icon="trash"
+                intent={Intent.DANGER}
+                isOpen={isDeleteConfirmationOpen}
+                onCancel={this.handleCancelDelete}
+                onConfirm={this.handleConfirmDelete}>
+                <p>
+                    Are you sure you want to delete the list <b>{`${list.title}`}</b>? You will not be able to undo
+                    this.
+                </p>
+            </Alert>
+        );
+    };
+
+    handleCancelDelete = () => {
+        this.setState({ isDeleteConfirmationOpen: false });
+    };
+
+    handleConfirmDelete = () => {
+        this.setState({ isDeleteConfirmationOpen: false });
         this.props.onListDelete(this.props.list);
+    };
+
+    handleAttemptDelete = () => {
+        this.setState({ isDeleteConfirmationOpen: true });
     };
 
     render() {
@@ -150,10 +183,11 @@ class List extends React.Component {
         return connectListDropTarget(
             connectListItemDropTarget(
                 <div style={dynamicStyle} className={className + ' List list-panel-item'}>
+                    {this.renderDeleteConfirmation()}
                     <ListTitle
                         title={list.title}
                         onRename={this.handleRename}
-                        onDelete={this.handleDelete}
+                        onDelete={this.handleAttemptDelete}
                         onCompleteAll={this.handleCompleteAll}
                         disabled={!canEditTitle}
                         showListMenu={showListMenu}


### PR DESCRIPTION
I used an `Alert` component. It's currently rendered by the `List` component itself..

At first I was going to do a conditional render based on `isDeleteConfirmationOpen`, but the `Alert` component doesn't render unless its `isOpen` prop is set to true. So since that controls whether or not it renders, I decided to leave out the conditional render.

Closes #6 