### PR TITLE
 Filter backlog tasks only by the selected lists

### DIFF
--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -211,18 +211,15 @@ class Board extends Component {
         };
 
         const filteredListIds = Set(filteredLists.map(l => l.id));
-        const selectedListIds = Set(lists
-            .map(list => list.id)
-            .filter(listId => !filteredListIds.contains(listId)));
+        const selectedListIds = Set(lists.map(list => list.id).filter(listId => !filteredListIds.contains(listId)));
 
         const fullyFilteredLists = lists
             .filter(list => selectedListIds.contains(list.id))
             .map(list => list.setItems(list.items.filter(filterFn)));
 
         const filteredBacklog = backlogList.setItems(
-            backlogList.items
-                .filter(filterFn)
-                .filter(item => Set(item.labels).intersect(selectedListIds).size === 0));
+            backlogList.items.filter(filterFn).filter(item => Set(item.labels).intersect(selectedListIds).size === 0)
+        );
 
         return (
             <div className="Board">

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -4,6 +4,7 @@ import flow from 'lodash/flow';
 import Dimensions from 'react-dimensions';
 import { Button, Intent, NonIdealState } from '@blueprintjs/core';
 import moment from 'moment';
+import { Set } from 'immutable';
 
 import Toolbar from './Toolbar';
 import ListsPanel from '../containers/ListsPanel';
@@ -209,11 +210,19 @@ class Board extends Component {
             return true;
         };
 
+        const filteredListIds = Set(filteredLists.map(l => l.id));
+        const selectedListIds = Set(lists
+            .map(list => list.id)
+            .filter(listId => !filteredListIds.contains(listId)));
+
         const fullyFilteredLists = lists
-            .filter(list => !filteredLists.map(l => l.id).contains(list.id))
+            .filter(list => selectedListIds.contains(list.id))
             .map(list => list.setItems(list.items.filter(filterFn)));
 
-        const filteredBacklog = backlogList.setItems(backlogList.items.filter(filterFn));
+        const filteredBacklog = backlogList.setItems(
+            backlogList.items
+                .filter(filterFn)
+                .filter(item => Set(item.labels).intersect(selectedListIds).size === 0));
 
         return (
             <div className="Board">

--- a/src/core/Item.js
+++ b/src/core/Item.js
@@ -14,7 +14,18 @@ const ItemRecord = Record({
 });
 
 export default class Item extends ItemRecord {
-    updateWith({ id, text, item_order, project, due_date_utc, priority, responsible_uid, date_added, date_string, labels }) {
+    updateWith({
+        id,
+        text,
+        item_order,
+        project,
+        due_date_utc,
+        priority,
+        responsible_uid,
+        date_added,
+        date_string,
+        labels,
+    }) {
         return new Item({
             id: id || this.id,
             text: text || this.text,

--- a/src/core/Item.js
+++ b/src/core/Item.js
@@ -10,10 +10,11 @@ const ItemRecord = Record({
     responsible_uid: null,
     date_added: '',
     date_string: '',
+    labels: [],
 });
 
 export default class Item extends ItemRecord {
-    updateWith({ id, text, item_order, project, due_date_utc, priority, responsible_uid, date_added, date_string }) {
+    updateWith({ id, text, item_order, project, due_date_utc, priority, responsible_uid, date_added, date_string, labels }) {
         return new Item({
             id: id || this.id,
             text: text || this.text,
@@ -24,6 +25,7 @@ export default class Item extends ItemRecord {
             responsible_uid: responsible_uid || this.responsible_uid,
             date_added: date_added || this.date_added,
             date_string: date_string || this.date_string,
+            labels: labels || this.labels,
         });
     }
 }

--- a/src/redux/modules/lists.js
+++ b/src/redux/modules/lists.js
@@ -437,16 +437,12 @@ function fetchSuccess(state, action) {
     const filteredLists = loadedLists.filter(el => filteredListIds.contains(el.id));
 
     // Create backlog.
-    // Important Note: when a label is deleted Todoist doesn't remove that label from any tasks that had that label
-    //                 but our Todoist client does filter those labels. So rather than just check if labels is empty
-    //                 we need to filter our backlog items to items that don't have a label that exists.
-    const labelIds = Set(labelList.map(l => l.id));
+    // Items will be filtered by the selected lists in Board.js
     const backlogList = new List({
         id: 0,
         title: 'Backlog',
         items: ImmutableList(
             items
-                .filter(item => Set.of(...item.labels).intersect(labelIds).size === 0)
                 .filter(item => {
                     // FIXME: remove items without a valid project (seen in wild, unsure how it happens)
                     const project = projectIdMap[item.project_id];


### PR DESCRIPTION
#29 

This allows Tasks with labels unrelated to the lists to appear in the backlog.