### PR TITLE
Add a filter for Labels that aren't lists

### DIFF
--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -211,18 +211,15 @@ class Board extends Component {
         };
 
         const filteredListIds = Set(filteredLists.map(l => l.id));
-        const selectedListIds = Set(lists
-            .map(list => list.id)
-            .filter(listId => !filteredListIds.contains(listId)));
+        const selectedListIds = Set(lists.map(list => list.id).filter(listId => !filteredListIds.contains(listId)));
 
         const fullyFilteredLists = lists
             .filter(list => selectedListIds.contains(list.id))
             .map(list => list.setItems(list.items.filter(filterFn)));
 
         const filteredBacklog = backlogList.setItems(
-            backlogList.items
-                .filter(filterFn)
-                .filter(item => Set(item.labels).intersect(selectedListIds).size === 0));
+            backlogList.items.filter(filterFn).filter(item => Set(item.labels).intersect(selectedListIds).size === 0)
+        );
 
         return (
             <div className="Board">

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -42,7 +42,7 @@ class Board extends Component {
             filteredLists,
             lists,
             filteredProjects,
-            filteredLabels,
+            selectedLabels,
             filteredPriorities,
             filterDueDate,
             namedFilter,
@@ -70,7 +70,7 @@ class Board extends Component {
                 updateListsFilter={actions.lists.updateListsFilter}
                 filteredProjects={filteredProjects}
                 updateProjectsFilter={actions.lists.updateProjectsFilter}
-                filteredLabels={filteredLabels}
+                selectedLabels={selectedLabels}
                 updateLabelsFilter={actions.lists.updateLabelsFilter}
                 onClearFilters={actions.lists.clearFilters}
             />
@@ -145,9 +145,7 @@ class Board extends Component {
 
         // Filtering Lists & Items
         const filteredProjectIds = filteredProjects.map(project => project.id);
-        const filteredLabelIds = Set(filteredLabels.map(label => label.id));
-        const selectedLabelIds = Set(filteredLists.map(list => list.id)).subtract(filteredLabelIds);
-
+        const selectedLabelIds = Set(selectedLabels.map(label => label.id));
         const filterStartMoment = filterDueDate.get('startDate', null);
         const filterEndMoment = filterDueDate.get('endDate', null);
         const dueDateFilterIsSet = filterStartMoment !== null && filterEndMoment !== null;
@@ -255,7 +253,7 @@ const mapStateToProps = state => {
         projects: state.lists.projects,
         defaultProjectId: state.lists.defaultProjectId,
         filteredProjects: state.lists.filteredProjects,
-        filteredLabels: state.lists.filteredLabels,
+        selectedLabels: state.lists.selectedLabels,
         filteredPriorities: state.lists.filteredPriorities,
         filterDueDate: state.lists.filterDueDate,
         namedFilter: state.lists.namedFilter,

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -42,6 +42,7 @@ class Board extends Component {
             filteredLists,
             lists,
             filteredProjects,
+            filteredLabels,
             filteredPriorities,
             filterDueDate,
             namedFilter,
@@ -69,6 +70,8 @@ class Board extends Component {
                 updateListsFilter={actions.lists.updateListsFilter}
                 filteredProjects={filteredProjects}
                 updateProjectsFilter={actions.lists.updateProjectsFilter}
+                filteredLabels={filteredLabels}
+                updateLabelsFilter={actions.lists.updateLabelsFilter}
                 onClearFilters={actions.lists.clearFilters}
             />
         );
@@ -142,6 +145,9 @@ class Board extends Component {
 
         // Filtering Lists & Items
         const filteredProjectIds = filteredProjects.map(project => project.id);
+        const filteredLabelIds = Set(filteredLabels.map(label => label.id));
+        const selectedLabelIds = Set(filteredLists.map(list => list.id)).subtract(filteredLabelIds);
+
         const filterStartMoment = filterDueDate.get('startDate', null);
         const filterEndMoment = filterDueDate.get('endDate', null);
         const dueDateFilterIsSet = filterStartMoment !== null && filterEndMoment !== null;
@@ -149,6 +155,10 @@ class Board extends Component {
         const filterFn = item => {
             // project
             if (filteredProjectIds.contains(item.project.id)) {
+                return false;
+            }
+
+            if (!selectedLabelIds.isSubset(Set(item.labels))) {
                 return false;
             }
 
@@ -245,6 +255,7 @@ const mapStateToProps = state => {
         projects: state.lists.projects,
         defaultProjectId: state.lists.defaultProjectId,
         filteredProjects: state.lists.filteredProjects,
+        filteredLabels: state.lists.filteredLabels,
         filteredPriorities: state.lists.filteredPriorities,
         filterDueDate: state.lists.filterDueDate,
         namedFilter: state.lists.namedFilter,

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -4,6 +4,7 @@ import flow from 'lodash/flow';
 import Dimensions from 'react-dimensions';
 import { Button, Intent, NonIdealState } from '@blueprintjs/core';
 import moment from 'moment';
+import { Set } from 'immutable';
 
 import Toolbar from './Toolbar';
 import ListsPanel from '../containers/ListsPanel';
@@ -209,11 +210,19 @@ class Board extends Component {
             return true;
         };
 
+        const filteredListIds = Set(filteredLists.map(l => l.id));
+        const selectedListIds = Set(lists
+            .map(list => list.id)
+            .filter(listId => !filteredListIds.contains(listId)));
+
         const fullyFilteredLists = lists
-            .filter(list => !filteredLists.map(l => l.id).contains(list.id))
+            .filter(list => selectedListIds.contains(list.id))
             .map(list => list.setItems(list.items.filter(filterFn)));
 
-        const filteredBacklog = backlogList.setItems(backlogList.items.filter(filterFn));
+        const filteredBacklog = backlogList.setItems(
+            backlogList.items
+                .filter(filterFn)
+                .filter(item => Set(item.labels).intersect(selectedListIds).size === 0));
 
         return (
             <div className="Board">

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -19,7 +19,7 @@ class Toolbar extends Component {
             projects,
             filteredProjects,
             updateProjectsFilter,
-            filteredLabels,
+            selectedLabels,
             updateLabelsFilter,
             showIfResponsible,
             toggleAssigneeFilter,
@@ -81,20 +81,20 @@ class Toolbar extends Component {
             <FilterMenu
                 title="Labels Filter"
                 checkboxItems={filteredLists}
-                selectedItems={filteredLists.filter(el => !filteredLabels.contains(el))}
+                selectedItems={filteredLists.filter(el => selectedLabels.contains(el))}
                 labelProperty="title"
                 onChange={(label, isChecked) => {
                     if (isChecked) {
-                        updateLabelsFilter(filteredLabels.filter(el => el.id !== label.id));
+                        updateLabelsFilter(selectedLabels.push(label));
                     } else {
-                        updateLabelsFilter(filteredLabels.push(label));
+                        updateLabelsFilter(selectedLabels.filter(el => el.id !== label.id));
                     }
                 }}
                 onChangeAll={isChecked => {
                     if (isChecked) {
-                        updateLabelsFilter(filteredLabels.filter(el => false));
-                    } else {
                         updateLabelsFilter(filteredLists);
+                    } else {
+                        updateLabelsFilter(selectedLabels.filter(el => false));
                     }
                 }}
             />

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -19,6 +19,8 @@ class Toolbar extends Component {
             projects,
             filteredProjects,
             updateProjectsFilter,
+            filteredLabels,
+            updateLabelsFilter,
             showIfResponsible,
             toggleAssigneeFilter,
             onClearFilters,
@@ -75,6 +77,29 @@ class Toolbar extends Component {
             />
         );
 
+        const labelsFilterMenu = (
+            <FilterMenu
+                title="Labels Filter"
+                checkboxItems={filteredLists}
+                selectedItems={filteredLists.filter(el => !filteredLabels.contains(el))}
+                labelProperty="title"
+                onChange={(label, isChecked) => {
+                    if (isChecked) {
+                        updateLabelsFilter(filteredLabels.filter(el => el.id !== label.id));
+                    } else {
+                        updateLabelsFilter(filteredLabels.push(label));
+                    }
+                }}
+                onChangeAll={isChecked => {
+                    if (isChecked) {
+                        updateLabelsFilter(filteredLabels.filter(el => false));
+                    } else {
+                        updateLabelsFilter(filteredLists);
+                    }
+                }}
+            />
+        );
+
         const priorityFilterMenu = (
             <FilterMenu
                 title="Priority Filter"
@@ -116,6 +141,15 @@ class Toolbar extends Component {
                     popoverClassName="pt-popover-content-sizing"
                     position={Position.BOTTOM}>
                     <Button text="Projects" iconName="projects" className="Toolbar-button" />
+                </Popover>
+
+                <Popover
+                    className="Toolbar-button Toolbar-button-popover"
+                    content={labelsFilterMenu}
+                    interactionKind={PopoverInteractionKind.CLICK}
+                    popoverClassName="pt-popover-content-sizing"
+                    position={Position.BOTTOM}>
+                    <Button text="Labels" iconName="projects" className="Toolbar-button" />
                 </Popover>
 
                 <Popover

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -149,7 +149,7 @@ class Toolbar extends Component {
                     interactionKind={PopoverInteractionKind.CLICK}
                     popoverClassName="pt-popover-content-sizing"
                     position={Position.BOTTOM}>
-                    <Button text="Labels" iconName="projects" className="Toolbar-button" />
+                    <Button text="Labels" iconName="tag" className="Toolbar-button" />
                 </Popover>
 
                 <Popover

--- a/src/core/Item.js
+++ b/src/core/Item.js
@@ -14,7 +14,18 @@ const ItemRecord = Record({
 });
 
 export default class Item extends ItemRecord {
-    updateWith({ id, text, item_order, project, due_date_utc, priority, responsible_uid, date_added, date_string, labels }) {
+    updateWith({
+        id,
+        text,
+        item_order,
+        project,
+        due_date_utc,
+        priority,
+        responsible_uid,
+        date_added,
+        date_string,
+        labels,
+    }) {
         return new Item({
             id: id || this.id,
             text: text || this.text,

--- a/src/core/Item.js
+++ b/src/core/Item.js
@@ -10,10 +10,11 @@ const ItemRecord = Record({
     responsible_uid: null,
     date_added: '',
     date_string: '',
+    labels: [],
 });
 
 export default class Item extends ItemRecord {
-    updateWith({ id, text, item_order, project, due_date_utc, priority, responsible_uid, date_added, date_string }) {
+    updateWith({ id, text, item_order, project, due_date_utc, priority, responsible_uid, date_added, date_string, labels }) {
         return new Item({
             id: id || this.id,
             text: text || this.text,
@@ -24,6 +25,7 @@ export default class Item extends ItemRecord {
             responsible_uid: responsible_uid || this.responsible_uid,
             date_added: date_added || this.date_added,
             date_string: date_string || this.date_string,
+            labels: labels || this.labels,
         });
     }
 }

--- a/src/redux/localStoragePersistence.js
+++ b/src/redux/localStoragePersistence.js
@@ -69,7 +69,7 @@ export function load() {
         // Filters
         let filteredListIds = Immutable.List(jsState.lists.filteredLists.map(el => el.id));
         let filteredProjectIds = Immutable.List(jsState.lists.filteredProjects.map(project => project.id));
-        let filteredLabelIds = Immutable.List(jsState.lists.filteredLabels.map(list => list.id));
+        let selectedLabelIds = Immutable.List(jsState.lists.selectedLabels.map(list => list.id));
         let filteredPriorities = Priorities.filter(p => jsState.lists.filteredPriorities.indexOf(p.id) >= 0);
 
         loadedState.lists.filterDueDate = Immutable.Map({
@@ -120,8 +120,8 @@ export function load() {
                 ? loadedState.lists.projects.filter(el => projects.indexOf(el.name) < 0).map(el => el.id)
                 : Immutable.List.of();
 
-            filteredLabelIds = labels
-                ? loadedState.lists.lists.filter(list => labels.indexOf(list.title) < 0).map(list => list.id)
+            selectedLabelIds = labels
+                ? loadedState.lists.lists.filter(list => labels.contains(list.title)).map(list => list.id)
                 : Immutable.List.of();
 
             filteredPriorities = priorities
@@ -145,8 +145,8 @@ export function load() {
         loadedState.lists.filteredProjects = loadedState.lists.projects.filter(project =>
             filteredProjectIds.contains(project.id)
         );
-        loadedState.lists.filteredLabels = loadedState.lists.filteredLists.filter(list => 
-            filteredLabelIds.contains(list.id)
+        loadedState.lists.selectedLabels = loadedState.lists.filteredLists.filter(list => 
+            selectedLabelIds.contains(list.id)
         );
         loadedState.lists.defaultProjectId = jsState.lists.defaultProjectId;
         loadedState.lists.filteredPriorities = filteredPriorities;

--- a/src/redux/localStoragePersistence.js
+++ b/src/redux/localStoragePersistence.js
@@ -145,7 +145,7 @@ export function load() {
         loadedState.lists.filteredProjects = loadedState.lists.projects.filter(project =>
             filteredProjectIds.contains(project.id)
         );
-        loadedState.lists.selectedLabels = loadedState.lists.filteredLists.filter(list => 
+        loadedState.lists.selectedLabels = loadedState.lists.filteredLists.filter(list =>
             selectedLabelIds.contains(list.id)
         );
         loadedState.lists.defaultProjectId = jsState.lists.defaultProjectId;

--- a/src/redux/localStoragePersistence.js
+++ b/src/redux/localStoragePersistence.js
@@ -121,7 +121,7 @@ export function load() {
                 : Immutable.List.of();
 
             selectedLabelIds = labels
-                ? loadedState.lists.lists.filter(list => labels.contains(list.title)).map(list => list.id)
+                ? loadedState.lists.lists.filter(list => labels.indexOf(list.title) >= 0).map(list => list.id)
                 : Immutable.List.of();
 
             filteredPriorities = priorities

--- a/src/redux/localStoragePersistence.js
+++ b/src/redux/localStoragePersistence.js
@@ -69,6 +69,7 @@ export function load() {
         // Filters
         let filteredListIds = Immutable.List(jsState.lists.filteredLists.map(el => el.id));
         let filteredProjectIds = Immutable.List(jsState.lists.filteredProjects.map(project => project.id));
+        let filteredLabelIds = Immutable.List(jsState.lists.filteredLabels.map(list => list.id));
         let filteredPriorities = Priorities.filter(p => jsState.lists.filteredPriorities.indexOf(p.id) >= 0);
 
         loadedState.lists.filterDueDate = Immutable.Map({
@@ -87,9 +88,10 @@ export function load() {
         // Filter from URL overrides redux state
 
         // Build map from query string to objects
-        const { lists, projects, priorities, start, end, assigned, filter } = Immutable.List([
+        const { lists, projects, labels, priorities, start, end, assigned, filter } = Immutable.List([
             'lists',
             'projects',
+            'labels',
             'priorities',
             'start',
             'end',
@@ -108,7 +110,7 @@ export function load() {
         }, {});
 
         // If ANY params are present then we ignore redux state for all filters and just use the URL
-        if (lists || projects || priorities || start || end || assigned || filter) {
+        if (lists || projects || labels || priorities || start || end || assigned || filter) {
             // lists
             filteredListIds = lists
                 ? loadedState.lists.lists.filter(el => lists.indexOf(el.title) < 0).map(el => el.id)
@@ -116,6 +118,10 @@ export function load() {
 
             filteredProjectIds = projects
                 ? loadedState.lists.projects.filter(el => projects.indexOf(el.name) < 0).map(el => el.id)
+                : Immutable.List.of();
+
+            filteredLabelIds = labels
+                ? loadedState.lists.lists.filter(list => labels.indexOf(list.title) < 0).map(list => list.id)
                 : Immutable.List.of();
 
             filteredPriorities = priorities
@@ -138,6 +144,9 @@ export function load() {
         loadedState.lists.filteredLists = loadedState.lists.lists.filter(list => filteredListIds.contains(list.id));
         loadedState.lists.filteredProjects = loadedState.lists.projects.filter(project =>
             filteredProjectIds.contains(project.id)
+        );
+        loadedState.lists.filteredLabels = loadedState.lists.filteredLists.filter(list => 
+            filteredLabelIds.contains(list.id)
         );
         loadedState.lists.defaultProjectId = jsState.lists.defaultProjectId;
         loadedState.lists.filteredPriorities = filteredPriorities;

--- a/src/redux/middleware/trelloist-filter-url.js
+++ b/src/redux/middleware/trelloist-filter-url.js
@@ -8,6 +8,7 @@ export function generateQueryString({
     projects,
     filteredLists,
     filteredProjects,
+    filteredLabels,
     filteredPriorities,
     filterDueDate,
     showIfResponsible,
@@ -33,6 +34,13 @@ export function generateQueryString({
         queryParams['projects'] = JSON.stringify(visibleProjects.toArray());
     }
 
+    if (!filteredLabels.isEmpty()) {
+        const visibleLabels = filteredLists
+            .filter(list => !filteredLabels.map(el => el.id).contains(list.id))
+            .map(list => list.title);
+
+        queryParams['labels'] = JSON.stringify(visibleLabels.toArray());
+    }
     if (!filteredPriorities.isEmpty()) {
         const visiblePriorities = priorities
             .filter(p => !filteredPriorities.map(el => el.id).contains(p.id))
@@ -80,6 +88,7 @@ const trelloistFilterUrl = store => next => action => {
         // fallthrough
         case types.UPDATE_LISTS_FILTER:
         case types.UPDATE_PROJECTS_FILTER:
+        case types.UPDATE_LABELS_FILTER:
         case types.UPDATE_DUE_DATE_FILTER:
         case types.SET_NAMED_FILTER:
         case types.UPDATE_PRIORITY_FILTER:

--- a/src/redux/middleware/trelloist-filter-url.js
+++ b/src/redux/middleware/trelloist-filter-url.js
@@ -8,7 +8,7 @@ export function generateQueryString({
     projects,
     filteredLists,
     filteredProjects,
-    filteredLabels,
+    selectedLabels,
     filteredPriorities,
     filterDueDate,
     showIfResponsible,
@@ -34,9 +34,9 @@ export function generateQueryString({
         queryParams['projects'] = JSON.stringify(visibleProjects.toArray());
     }
 
-    if (!filteredLabels.isEmpty()) {
+    if (!selectedLabels.isEmpty()) {
         const visibleLabels = filteredLists
-            .filter(list => !filteredLabels.map(el => el.id).contains(list.id))
+            .filter(list => selectedLabels.map(el => el.id).contains(list.id))
             .map(list => list.title);
 
         queryParams['labels'] = JSON.stringify(visibleLabels.toArray());

--- a/src/redux/modules/lists.js
+++ b/src/redux/modules/lists.js
@@ -48,7 +48,7 @@ const initialState = {
     projects: ImmutableList.of(),
     defaultProjectId: undefined,
     filteredProjects: ImmutableList.of(),
-    filteredLabels: ImmutableList.of(),
+    selectedLabels: ImmutableList.of(),
     filterDueDate: Map({ startDate: null, endDate: null }),
     filteredPriorities: ImmutableList.of(),
     showIfResponsible: false,
@@ -120,7 +120,7 @@ export const actions = {
     clearAll: () => ({ type: types.CLEAR_ALL }),
     updateListsFilter: filteredLists => ({ type: types.UPDATE_LISTS_FILTER, payload: { filteredLists } }),
     updateProjectsFilter: filteredProjects => ({ type: types.UPDATE_PROJECTS_FILTER, payload: { filteredProjects } }),
-    updateLabelsFilter: filteredLabels => ({ type: types.UPDATE_LABELS_FILTER, payload: { filteredLabels } }),
+    updateLabelsFilter: selectedLabels => ({ type: types.UPDATE_LABELS_FILTER, payload: { selectedLabels } }),
     updateDueDateFilter: (startDate, endDate) => ({
         type: types.UPDATE_DUE_DATE_FILTER,
         payload: { startDate, endDate },
@@ -375,8 +375,8 @@ function updateProjectsFilter(state, action) {
 }
 
 function updateLabelsFilter(state, action) {
-    const { filteredLabels } = action.payload;
-    return { ...state, filteredLabels };
+    const { selectedLabels } = action.payload;
+    return { ...state, selectedLabels };
 }
 
 function updatePriorityFilter(state, action) {
@@ -470,8 +470,8 @@ function fetchSuccess(state, action) {
     const filteredProjectsIds = state.filteredProjects.map(el => el.id);
     const filteredProjects = loadedProjects.filter(el => filteredProjectsIds.contains(el.id));
 
-    const filteredLabelIds = state.filteredLabels.map(list => list.id);
-    const filteredLabels = loadedLists.filter(list => filteredLabelIds.contains(list.id));
+    const selectedLabelIds = state.selectedLabels.map(list => list.id);
+    const selectedLabels = loadedLists.filter(list => selectedLabelIds.contains(list.id));
     
     return {
         ...state,
@@ -479,7 +479,7 @@ function fetchSuccess(state, action) {
         filteredProjects,
         lists: loadedLists,
         filteredLists,
-        filteredLabels,
+        selectedLabels,
         backlog: backlogList,
         fetching: false,
         fetchFail: null,
@@ -614,7 +614,7 @@ export const reducer = (state = initialState, action) => {
                 ...state,
                 filteredProjects: initialState.filteredProjects,
                 filteredLists: initialState.filteredLists,
-                filteredLabels: initialState.filteredLabels,
+                selectedLabels: initialState.selectedLabels,
                 filterDueDate: initialState.filterDueDate,
                 filteredPriorities: initialState.filteredPriorities,
                 showIfResponsible: false,

--- a/src/redux/modules/lists.js
+++ b/src/redux/modules/lists.js
@@ -48,6 +48,7 @@ const initialState = {
     projects: ImmutableList.of(),
     defaultProjectId: undefined,
     filteredProjects: ImmutableList.of(),
+    filteredLabels: ImmutableList.of(),
     filterDueDate: Map({ startDate: null, endDate: null }),
     filteredPriorities: ImmutableList.of(),
     showIfResponsible: false,
@@ -76,6 +77,7 @@ export const types = {
     CLEAR_ALL: 'CLEAR_ALL',
     UPDATE_LISTS_FILTER: 'UPDATE_LISTS_FILTER',
     UPDATE_PROJECTS_FILTER: 'UPDATE_PROJECTS_FILTER',
+    UPDATE_LABELS_FILTER: 'UPDATE_LABELS_FILTER',
     UPDATE_DUE_DATE_FILTER: 'UPDATE_DUE_DATE_FILTER',
     UPDATE_PRIORITY_FILTER: 'UPDATE_PRIORITY_FILTER',
     TOGGLE_ASSIGNEE_FILTER: 'TOGGLE_ASSIGNEE_FILTER',
@@ -118,6 +120,7 @@ export const actions = {
     clearAll: () => ({ type: types.CLEAR_ALL }),
     updateListsFilter: filteredLists => ({ type: types.UPDATE_LISTS_FILTER, payload: { filteredLists } }),
     updateProjectsFilter: filteredProjects => ({ type: types.UPDATE_PROJECTS_FILTER, payload: { filteredProjects } }),
+    updateLabelsFilter: filteredLabels => ({ type: types.UPDATE_LABELS_FILTER, payload: { filteredLabels } }),
     updateDueDateFilter: (startDate, endDate) => ({
         type: types.UPDATE_DUE_DATE_FILTER,
         payload: { startDate, endDate },
@@ -371,6 +374,11 @@ function updateProjectsFilter(state, action) {
     return { ...state, filteredProjects };
 }
 
+function updateLabelsFilter(state, action) {
+    const { filteredLabels } = action.payload;
+    return { ...state, filteredLabels };
+}
+
 function updatePriorityFilter(state, action) {
     const { filteredPriorities } = action.payload;
     return { ...state, filteredPriorities };
@@ -462,12 +470,16 @@ function fetchSuccess(state, action) {
     const filteredProjectsIds = state.filteredProjects.map(el => el.id);
     const filteredProjects = loadedProjects.filter(el => filteredProjectsIds.contains(el.id));
 
+    const filteredLabelIds = state.filteredLabels.map(list => list.id);
+    const filteredLabels = loadedLists.filter(list => filteredLabelIds.contains(list.id));
+    
     return {
         ...state,
         projects: loadedProjects,
         filteredProjects,
         lists: loadedLists,
         filteredLists,
+        filteredLabels,
         backlog: backlogList,
         fetching: false,
         fetchFail: null,
@@ -579,6 +591,8 @@ export const reducer = (state = initialState, action) => {
             return updateListsFilter(state, action);
         case types.UPDATE_PROJECTS_FILTER:
             return updateProjectsFilter(state, action);
+        case types.UPDATE_LABELS_FILTER:
+            return updateLabelsFilter(state, action);
         case types.UPDATE_DUE_DATE_FILTER:
             return updateDueDateFilter(state, action);
         case types.UPDATE_PRIORITY_FILTER:
@@ -600,6 +614,7 @@ export const reducer = (state = initialState, action) => {
                 ...state,
                 filteredProjects: initialState.filteredProjects,
                 filteredLists: initialState.filteredLists,
+                filteredLabels: initialState.filteredLabels,
                 filterDueDate: initialState.filterDueDate,
                 filteredPriorities: initialState.filteredPriorities,
                 showIfResponsible: false,

--- a/src/redux/modules/lists.js
+++ b/src/redux/modules/lists.js
@@ -472,7 +472,7 @@ function fetchSuccess(state, action) {
 
     const selectedLabelIds = state.selectedLabels.map(list => list.id);
     const selectedLabels = loadedLists.filter(list => selectedLabelIds.contains(list.id));
-    
+
     return {
         ...state,
         projects: loadedProjects,

--- a/src/redux/modules/lists.js
+++ b/src/redux/modules/lists.js
@@ -437,16 +437,12 @@ function fetchSuccess(state, action) {
     const filteredLists = loadedLists.filter(el => filteredListIds.contains(el.id));
 
     // Create backlog.
-    // Important Note: when a label is deleted Todoist doesn't remove that label from any tasks that had that label
-    //                 but our Todoist client does filter those labels. So rather than just check if labels is empty
-    //                 we need to filter our backlog items to items that don't have a label that exists.
-    const labelIds = Set(labelList.map(l => l.id));
+    // Items will be filtered by the selected lists in Board.js
     const backlogList = new List({
         id: 0,
         title: 'Backlog',
         items: ImmutableList(
             items
-                .filter(item => Set.of(...item.labels).intersect(labelIds).size === 0)
                 .filter(item => {
                     // FIXME: remove items without a valid project (seen in wild, unsure how it happens)
                     const project = projectIdMap[item.project_id];


### PR DESCRIPTION
This also contains change #30 
Resolves Issue #29 

This adds a new Filter button to the Toolbar for Labels.
- The set of Labels is take from filteredLists.
- The set of selectedLabels is saved to the url as 'labels'.
- A task is filtered unless it as all of the labels in selectedLabels.

Otherwise I tried to follow the conventions used by the Project Filtering box as closely as possible.
