### PR TITLE
Prevent hash signs from being interpreted as h tags

### DIFF
--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -58,7 +58,9 @@ class ListItem extends React.Component {
         return markdown
             .toHTML(todoistToMd)
             .replace(/<\/?p>/g, '')
-            .replace(/a href/g, 'a target="_blank" href');
+            .replace(/a href/g, 'a target="_blank" href')
+            .replace(/<h(\d)>/g, (_, num) => '#'.repeat(num))
+            .replace(/<\/h\d>/g, '');
     };
 
     formatOutlookLink = text => {

--- a/src/pages/Issues.js
+++ b/src/pages/Issues.js
@@ -18,22 +18,6 @@ export default () => (
                 </em>
                 .
             </p>
-            <h4>ISSUE 02: Quick add tasks.</h4>
-            <p>
-                Kanbanist allows you to use Todoist{' '}
-                <a href="https://support.todoist.com/hc/en-us/articles/115001745265-Task-Quick-Add">
-                    Quick Add syntax{' '}
-                </a>
-                when creating new tasks (note: this is not possible when editing existing tasks). Unlike the regular
-                Todoist client, projects must be quick added without spaces. For example, if your project is called
-                "Reading List", then you quick add a task by inserting "#readinglist". Also, because Kanbanist uses a
-                more complete markdown converter, putting your project at the beginning of a task will show it (briefly)
-                as a heading. To not see this, put your project syntax within or at the end of your item. For example,
-                type "thing to do #project" rather than "#project thing to do".
-            </p>
-            <h4>
-                <strike>ISSUE 03: Quick-Add fails when project name contains emojis.</strike>
-            </h4>
             <h4>ISSUE 04: General support for Todoist Filters</h4>
             <p>
                 I've received a number of requests for supporting Todoist Filters in various ways. Most commonly to


### PR DESCRIPTION
Hello.  
I found when a task name contains hash signs (`#`), they are interpreted as `<h1>`. This causes the layout issue like the following.  
## Example
Suppose I created tasks named `#typo my task` and `##double hash`, where there are no projects named `typo` and `double`.  
Todoist shows these tasks with hash signs maintained:
![image](https://user-images.githubusercontent.com/42759138/55024889-24af2600-5043-11e9-942c-af526da9dd5d.png)  
However, since Kanbanist interprets a task name as markdown, `#` is translated into `<h1>`:
![image](https://user-images.githubusercontent.com/42759138/55024389-157ba880-5042-11e9-918f-76bf514c9ea9.png)  

## Solution
Replace `<h1>` in a task name with `#`. Also, `<h(\d)>` will be like `'#' * $1`.
![image](https://user-images.githubusercontent.com/42759138/55025535-6db3aa00-5044-11e9-873f-6cd974f4ee6d.png)
