### PR TITLE
Prevent app component from showing scrollbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7,6 +7,9 @@
 }
 
 .App {
+  position: relative;
+  height: 100vh;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
## Problem
When a list has so many tasks that the items in the list run over the bottom of the screen, the app shows a scroll bar.
![image](https://user-images.githubusercontent.com/42759138/57748387-ba4a6600-7714-11e9-8ed6-514fa35c5d68.png)  
When scrolling down,
![image](https://user-images.githubusercontent.com/42759138/57748464-04334c00-7715-11e9-95e9-fc2167ce157c.png)
This behavior is a bit stressful.
## Solution
Update style of `.App`