### PR TITLE
Show time for tasks with a due date that includes a time

### DIFF
--- a/src/components/ListItemDueDate.js
+++ b/src/components/ListItemDueDate.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import moment from 'moment';
+import { parseDueDate } from '../core/DueDate';
 
 const DISPLAY_TYPE = {
     DATE: 'DATE',
@@ -11,7 +11,7 @@ export default class ListItemDueDate extends React.Component {
         super(props);
         const { dueDate } = props;
         this.state = {
-            dueMoment: dueDate ? moment(dueDate) : null,
+            dueDate: dueDate ? parseDueDate(dueDate) : null,
             displayType: DISPLAY_TYPE.DATE,
         };
     }
@@ -23,25 +23,25 @@ export default class ListItemDueDate extends React.Component {
     };
 
     render() {
-        const { dueMoment, displayType } = this.state;
+        const { dueDate, displayType } = this.state;
 
-        if (dueMoment === null) {
+        if (dueDate === null) {
             return null;
         }
 
         let text = '';
         switch (displayType) {
             case DISPLAY_TYPE.DATE:
-                text = dueMoment.format('Do MMM');
+                text = dueDate.format();
                 break;
             case DISPLAY_TYPE.RELATIVE:
-                text = dueMoment.fromNow();
+                text = dueDate.due_moment.fromNow();
                 break;
             default:
                 console.error('Unknown displayType for ListItemDueDate: ', displayType);
         }
 
-        const classes = ['ListItem-project-duedate', dueMoment.isBefore(moment()) ? 'overdue' : ''].join(' ');
+        const classes = ['ListItem-project-duedate', dueDate.isExpired() ? 'overdue' : ''].join(' ');
 
         return (
             <span className={classes} onClick={this.handleToggleDisplayType}>

--- a/src/core/DueDate.js
+++ b/src/core/DueDate.js
@@ -1,0 +1,40 @@
+import { Record } from 'immutable';
+import moment from 'moment';
+
+const DueDateRecord = Record({
+    due_moment: null,
+    has_time: false,
+});
+
+export default class DueDate extends DueDateRecord {
+    updateWith({ due_moment, has_time }) {
+        return new DueDate({
+            due_moment: due_moment || this.due_moment,
+            has_time: has_time != null ? has_time : this.has_time,
+        });
+    }
+
+    isExpired() {
+        return this.due_moment.isBefore(moment());
+    }
+
+    format() {
+        const dueDateFormat = this.has_time ? 'Do MMM LT' : 'Do MMM';
+        return this.due_moment.format(dueDateFormat);
+    }
+}
+
+export const parseDueDate = (dateTimeStr) => {
+    const due_moment = moment(dateTimeStr);
+    let has_time = true;
+    // If time is exactly zero and no colon is found in the ISO 8601 datetime string, it means
+    // no time was given.
+    if ((due_moment.hours() === 0)
+        && (due_moment.minutes() === 0)
+        && (due_moment.seconds() === 0)
+        && (due_moment.milliseconds() === 0)
+        && !/:/.test(dateTimeStr)) {
+        has_time = false;
+    }
+    return new DueDate({due_moment, has_time});
+};


### PR DESCRIPTION
Fixes #57.

Uses heuristics to recover whether a date had an explicit time after parsing because JS date utilities make it impossible to tell directly whether there's an explicit time, and JS developers don't seem to have any helpful solutions besides just suggesting you overload "00:00" to mean "no time" (e.g., https://stackoverflow.com/questions/21171794/check-if-a-moment-contains-a-time).