### PR TITLE
Issue #48: Restore due-dates to tasks in backlog.

### DIFF
--- a/src/redux/modules/lists.js
+++ b/src/redux/modules/lists.js
@@ -463,7 +463,13 @@ function fetchSuccess(state, action) {
                     return !!project;
                 })
                 .filter(item => !item.checked)
-                .map(item => new Item({ ...item, text: item.content, project: projectIdMap[item.project_id] }))
+                .map(item => new Item({
+                    ...item,
+                    due_date_utc: item.due && item.due.date,
+                    recurring: item.due && item.due.is_recurring,
+                    text: item.content,
+                    project: projectIdMap[item.project_id],
+                }))
         ),
     });
 


### PR DESCRIPTION
Closes #48.

This was an oversight from when migrating from Todoist API v7 to v8.